### PR TITLE
Fix Module Unavailable Error "$injector:nomod"

### DIFF
--- a/remove-diacritics.js
+++ b/remove-diacritics.js
@@ -3,7 +3,7 @@
  */
 
 angular
-	.module('txx.diacritics')
+	.module('txx.diacritics', [])
 	.service('removeDiacritics', function () {
 		var MAP = [
 			{


### PR DESCRIPTION
To define a new module we should use angular.module('txx.diacritics', []) instead angular.module('txx.diacritics')
