### PR TITLE
Made sure the plugin can be used by any Angular 1.x version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,6 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.3.8"
+    "angular": "~1.x"
   }
 }


### PR DESCRIPTION
During my Bower install it asked me to resolve the Angular version for your repo because ~1.3.8 from your Bower.json has become quite low. I made it so it's compatible with every 1.x release. It worked in my 1.4.7 environment, but I'm pretty certain it will work in 1.5.x as well.
